### PR TITLE
Do not translate numbers or booleans

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -170,6 +170,9 @@ export function activate(context: vscode.ExtensionContext) {
         // if we already have a translation, keep it
         if (keepTranslations && original[term]) {
           destination[term] = original[term];
+        } else if (typeof node === "number" || typeof node === "boolean") {
+          // numbers and booleans do not need translations
+          destination[term] = node;
         } else {
           var translation = await googleTranslate
             .translateText(node, locale)


### PR DESCRIPTION
No need to translate numbers or booleans.  resolves #17

It might be ok to also parse values and see if they are numbers and not translate them either.
F.x
`"code": "12.4"`
This is not included in the pull request.