### PR TITLE
add option to specify different delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,19 @@ This extension contributes the following settings (Menu>Preferences>Settings):
 
 - `auto-translate-json.azureRegion`: Enter your Azure region in this setting.
 
+### Mode
+
+- `auto-translate-json.mode`: Enter \"file\" if translations are files in same folder like \"en.json\"
+   or \"folder\" if translation files are in sub folders like \"en/translation.json\"
+
+### Start delimiter
+
+- `auto-translate-json.startDelimiter`: Start delimiter for named arguments. Defaults to \"{\"
+if you use ngx-transate or ngx-transloco you should use \"{{\"
+
+- `auto-translate-json.endDelimiter`: End delimiter for named arguments. Defaults to \"}\"
+if you use ngx-transate or ngx-transloco you should use \"}}\"
+
 ## Limitations
 
 - files must be named with the locale code that may be different depending on the translation service that you use. Please see the supported languages above.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ This extension contributes the following settings (Menu>Preferences>Settings):
 - `auto-translate-json.startDelimiter`: Start delimiter for named arguments. Defaults to \"{\"
 if you use ngx-transate or ngx-transloco you should use \"{{\"
 
+### End delimiter
+
 - `auto-translate-json.endDelimiter`: End delimiter for named arguments. Defaults to \"}\"
 if you use ngx-transate or ngx-transloco you should use \"}}\"
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "auto-translate-json.sourceLocale": {
           "type": "string",
           "default": "en",
-          "markdownDescription": "The local to use for generation from. This prevents accidently clicking the wrong file. Leave blank to process from any file."
+          "markdownDescription": "The local to use for generation from. This prevents accidentally clicking the wrong file. Leave blank to process from any file."
         },
         "auto-translate-json.googleApiKey": {
           "type": "string",
@@ -77,6 +77,16 @@
             "folder"
           ],
           "markdownDescription": "\"file\": files in same folder like \"en.json\"...; \"folder\": files in subfolders like \"en/translation.json\""
+        },
+        "auto-translate-json.startDelimiter": {
+          "type": "string",
+          "default": "{",
+          "markdownDescription": "Start delimiter for named arguments"
+        },
+        "auto-translate-json.endDelimiter": {
+          "type": "string",
+          "default": "}",
+          "markdownDescription": "End delimiter for named arguments"
         }
       }
     },

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -4,7 +4,7 @@ import {
   Translate,
   TranslateTextCommandInput
 } from '@aws-sdk/client-translate';
-import { replaceArgumentsWithNumbers, replaceContextVariables } from './util';
+import { Util } from './util';
 
 const supportedLanguages = [
   'af',
@@ -108,7 +108,7 @@ export class AWSTranslate implements ITranslate {
     targetLocale: string
   ): Promise<string> {
     let args;
-    ({ args, text } = replaceContextVariables(text));
+    ({ args, text } = Util.replaceContextVariables(text));
 
     let result = '';
 
@@ -126,7 +126,7 @@ export class AWSTranslate implements ITranslate {
       return '';
     }
 
-    result = replaceArgumentsWithNumbers(args, result);
+    result = Util.replaceArgumentsWithNumbers(args, result);
 
     return result;
   }

--- a/src/azure.ts
+++ b/src/azure.ts
@@ -1,5 +1,5 @@
 import { ITranslate } from './translate.interface';
-import { replaceArgumentsWithNumbers, replaceContextVariables } from './util';
+import { Util } from './util';
 
 const axios = require('axios').default;
 const { v4: uuidv4 } = require('uuid');
@@ -125,7 +125,7 @@ export class AzureTranslate implements ITranslate {
     targetLocale: string
   ): Promise<string> {
     let args;
-    ({ args, text } = replaceContextVariables(text));
+    ({ args, text } = Util.replaceContextVariables(text));
 
     let result = '';
 
@@ -153,7 +153,7 @@ export class AzureTranslate implements ITranslate {
     });
     result = response.data;
 
-    result = replaceArgumentsWithNumbers(args, result);
+    result = Util.replaceArgumentsWithNumbers(args, result);
 
     return result;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { AWSTranslate } from './aws';
 import { AzureTranslate } from './azure';
 import { GoogleTranslate } from './google';
 import { ITranslate } from './translate.interface';
+import { Util } from './util';
 
 const NAME = 'AutoTranslateJSON';
 
@@ -59,6 +60,23 @@ export function activate(context: vscode.ExtensionContext) {
         );
 
         return;
+      }
+
+      // set the delimiters for named arguments
+      const startDelimiter = vscode.workspace
+        .getConfiguration()
+        .get('auto-translate-json.startDelimiter') as string;
+
+      if (startDelimiter) {
+        Util.startDelimiter = startDelimiter;
+      }
+
+      const endDelimiter = vscode.workspace
+        .getConfiguration()
+        .get('auto-translate-json.endDelimiter') as string;
+
+      if (endDelimiter) {
+        Util.endDelimiter = endDelimiter;
       }
 
       let translateEngine: ITranslate;

--- a/src/google.ts
+++ b/src/google.ts
@@ -2,7 +2,7 @@ import { ITranslate } from './translate.interface';
 
 //const {Translate} = require('@google-cloud/translate').v2;
 import { Translate } from '@google-cloud/translate/build/src/v2';
-import { replaceContextVariables, replaceArgumentsWithNumbers } from './util';
+import { Util } from './util';
 const supportedLanguages = [
   'af',
   'sq',
@@ -117,12 +117,12 @@ const supportedLanguages = [
 ];
 export class GoogleTranslate implements ITranslate {
   private apikey: string;
-  private googleTranslate:  Translate;
+  private googleTranslate: Translate;
 
   constructor(apikey: string) {
     this.apikey = apikey;
-    this.googleTranslate = new  Translate({ key: this.apikey });
-   // this.googleTranslate.getSupportedLanguages();
+    this.googleTranslate = new Translate({ key: this.apikey });
+    // this.googleTranslate.getSupportedLanguages();
   }
 
   isValidLocale(targetLocale: string): boolean {
@@ -135,7 +135,7 @@ export class GoogleTranslate implements ITranslate {
     targetLocale: string
   ): Promise<string> {
     let args;
-    ({ args, text } = replaceContextVariables(text));
+    ({ args, text } = Util.replaceContextVariables(text));
 
     let result = '';
 
@@ -151,11 +151,11 @@ export class GoogleTranslate implements ITranslate {
         console.log(message);
         return message;
       }
-      return "error";
+      return 'error';
     }
 
     // replace arguments with numbers
-    result = replaceArgumentsWithNumbers(args, result);
+    result = Util.replaceArgumentsWithNumbers(args, result);
 
     return result;
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,28 +1,48 @@
-export function replaceArgumentsWithNumbers(
-  args: RegExpMatchArray | null,
-  result: string
-) {
-  if (args) {
-    let i = 0;
-    for (let arg of args) {
-      result = result.replace('{' + i + '}', arg);
-      i++;
-    }
-  }
-  return result;
-}
+export class Util {
+  private static _startDelimiter = '{';
+  private static _endDelimiter = '}';
 
-export function replaceContextVariables(text: string) {
-  const pattern = /{(.*?)}/g;
-  const args = text.match(pattern);
-
-  // replace arguments with numbers
-  if (args) {
-    let i = 0;
-    for (let arg of args) {
-      text = text.replace(arg, '{' + i + '}');
-      i++;
-    }
+  public static set startDelimiter(value: string) {
+    Util._startDelimiter = value;
   }
-  return { args, text };
+
+  // TODO calculate regex once
+
+  public static set endDelimiter(value: string) {
+    Util._endDelimiter = value;
+  }
+  public static replaceArgumentsWithNumbers(
+    args: RegExpMatchArray | null,
+    result: string
+  ) {
+    if (args) {
+      let i = 0;
+      for (let arg of args) {
+        result = result.replace(
+          Util._startDelimiter + i + Util._endDelimiter,
+          arg
+        );
+        i++;
+      }
+    }
+    return result;
+  }
+
+  public static replaceContextVariables(text: string) {
+    const pattern = new RegExp(
+      Util._startDelimiter + '(.*?)' + Util._endDelimiter,
+      'g'
+    );
+    const args = text.match(pattern);
+
+    // replace arguments with numbers
+    if (args) {
+      let i = 0;
+      for (let arg of args) {
+        text = text.replace(arg, Util._startDelimiter + i + Util._endDelimiter);
+        i++;
+      }
+    }
+    return { args, text };
+  }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,15 +1,27 @@
 export class Util {
   private static _startDelimiter = '{';
   private static _endDelimiter = '}';
+  private static pattern = new RegExp(
+    Util._startDelimiter + '(.*?)' + Util._endDelimiter,
+    'g'
+  );
 
   public static set startDelimiter(value: string) {
     Util._startDelimiter = value;
+    // update regex
+    Util.pattern = new RegExp(
+      Util._startDelimiter + '(.*?)' + Util._endDelimiter,
+      'g'
+    );
   }
-
-  // TODO calculate regex once
 
   public static set endDelimiter(value: string) {
     Util._endDelimiter = value;
+    // update regex
+    Util.pattern = new RegExp(
+      Util._startDelimiter + '(.*?)' + Util._endDelimiter,
+      'g'
+    );
   }
   public static replaceArgumentsWithNumbers(
     args: RegExpMatchArray | null,
@@ -29,11 +41,8 @@ export class Util {
   }
 
   public static replaceContextVariables(text: string) {
-    const pattern = new RegExp(
-      Util._startDelimiter + '(.*?)' + Util._endDelimiter,
-      'g'
-    );
-    const args = text.match(pattern);
+    
+    const args = text.match(Util.pattern);
 
     // replace arguments with numbers
     if (args) {


### PR DESCRIPTION

for example for [ngx-translate](https://github.com/ngx-translate/core)
and [transloco ](https://github.com/ngneat/transloco/)delimiters
should be {{ and }}

update README.md