### PR TITLE
fix issue 10 https://github.com/codegrue/auto-translate-json/issues/10

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -218,9 +218,10 @@ export function activate(context: vscode.ExtensionContext) {
     keepExtras: boolean | null,
     sourceLocale: string,
     locale: string,
-    googleTranslate: ITranslate
+    translateEngine: ITranslate,
+    isArray: boolean = false
   ): Promise<any> {
-    const destination: any = {};
+    const destination: any = isArray ? [] : {};
 
     // defaults
     if (keepTranslations === null) {
@@ -241,7 +242,8 @@ export function activate(context: vscode.ExtensionContext) {
           keepExtras,
           sourceLocale,
           locale,
-          googleTranslate
+          translateEngine,
+          node instanceof Array && node !== null
         );
       } else {
         // if we already have a translation, keep it
@@ -251,7 +253,7 @@ export function activate(context: vscode.ExtensionContext) {
           // numbers and booleans do not need translations
           destination[term] = node;
         } else {
-          const translation = await googleTranslate
+          const translation = await translateEngine
             .translateText(node, sourceLocale, locale)
             .catch((err) => showError(err));
           destination[term] = translation;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -243,7 +243,7 @@ export function activate(context: vscode.ExtensionContext) {
           sourceLocale,
           locale,
           translateEngine,
-          node instanceof Array && node !== null
+          node instanceof Array
         );
       } else {
         // if we already have a translation, keep it


### PR DESCRIPTION
rename googleTranslate to translateEngine add aditional parameter isArray
in order to better hanle Arrays
not to traet them as objects
so fix issue 10
https://github.com/codegrue/auto-translate-json/issues/10